### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,7 +58,7 @@ async def lifespan(app: FastAPI):
         async_session = await db.helpers.init_db(engine)
     except InvalidPasswordError:
         # The password was provided but authentication failed
-        msg = f"Invalid password provided for DB user '{user}': {password!r}"
+        msg = f"Invalid password provided for DB user '{user}'."
         logger.error(msg)
         raise RuntimeError(msg)
     except Exception as exc:


### PR DESCRIPTION
Potential fix for [https://github.com/random-iceberg/web-backend/security/code-scanning/2](https://github.com/random-iceberg/web-backend/security/code-scanning/2)

To fix the issue, we need to ensure that sensitive data, such as the database password, is not logged. Instead of including the password in the log message, we can log a generic error message that does not expose sensitive information. This approach maintains the functionality of logging errors while adhering to security best practices.

Specifically:
1. Replace the log message on line 62 to exclude the password.
2. Use a generic message like "Invalid password provided for DB user" without revealing the actual password.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
