### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/random-iceberg/web-backend/security/code-scanning/1](https://github.com/random-iceberg/web-backend/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `test` job. Since the `test` job only runs tests and does not require write access, we will set the permissions to `contents: read`. This ensures that the job has the minimal permissions necessary to execute its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
